### PR TITLE
many: pre-release versions support & switch-case

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,11 +55,12 @@ func main() {
 	flag.IntVar(&retries, "retries", 5, "number of downgrade retries for each module (default: 5)")
 	flag.Parse()
 
-	if format == "markdown" {
+	switch format {
+	case "markdown":
 		out = NewOutputMarkdown(os.Stdout)
-	} else if format == "console" {
+	case "console":
 		out = &OutputConsole{}
-	} else {
+	default:
 		out = &OutputNone{}
 	}
 

--- a/main.go
+++ b/main.go
@@ -79,16 +79,17 @@ func main() {
 
 	proxy := NewGoProxy("")
 
-	var newMod *modfile.File
+	newMod := parse(gomodsrc)
 	for _, r := range original.Require {
 		if !r.Indirect {
 			success := true
 			lastMod := modules[len(modules)-1]
+
 			out.BeginPreformatted(goBinary, "get", r.Mod.Path)
-			versions, err := proxy.FetchVersions(r.Mod.Path)
+			versions, err := proxy.FetchVersions(r.Mod.Path, r.Mod.Version)
 			if err != nil {
 				out.Error("failed to fetch versions:", err.Error())
-				out.EndPreformatted(false)
+				out.EndPreformattedCond(false)
 				continue
 			}
 			for vi, version := range versions {


### PR DESCRIPTION
proxy: pre-release versions support

When current module version is a pre-release, then fetch all versions
including pre-releases from the Go proxy and try to upgrade. This
includes both stable and unstable versions.

But if the currentl module version is a stable version, then exclude
pre-release versions from the list of available versions.

This behavior also means that if a current version is pinned to a
pre-release, gobump will keep upgrading pre-releases until the first
stable version is reached. After that, only stable versions will be
considered.

---

Plus one additional tiny commit to silence a linter.